### PR TITLE
CI: Fix warnings & deprecation messages in the workflows 

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,8 +1,0 @@
----
-version: 2
-
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/.github/workflows/update-consul-versions.yml
+++ b/.github/workflows/update-consul-versions.yml
@@ -3,12 +3,13 @@ name: "Update Consul versions"
 on:
   schedule:
     - cron: '22 2 * * *' # Run once per day, at a randomly chosen time.
+  pull_request:
 
 jobs:
   update-consul-versions:
     # Only run on main repository
     # Scheduled workflows do not have information about fork status, hence the hardcoded check
-    if: github.repository == 'G-Research/consuldotnet'
+    # if: github.repository == 'G-Research/consuldotnet'
     environment: update-consul-versions
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-consul-versions.yml
+++ b/.github/workflows/update-consul-versions.yml
@@ -30,7 +30,7 @@ jobs:
           installation_id=$(curl -s -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer $jwt" https://api.github.com/app/installations | jq '.[] | select(.account.login == "${{ github.repository_owner }}") | .id')
           token=$(curl -s -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer $jwt" https://api.github.com/app/installations/$installation_id/access_tokens | jq -r '.token')
           echo "::add-mask::$token"
-          echo "::set-output name=token::$token"
+          echo "token=$token" >> $GITHUB_OUTPUT
 
       - name: Install PowerShellForGitHub
         shell: pwsh

--- a/.github/workflows/update-consul-versions.yml
+++ b/.github/workflows/update-consul-versions.yml
@@ -1,7 +1,6 @@
 name: "Update Consul versions"
 
 on:
-  push:
   schedule:
     - cron: '22 2 * * *' # Run once per day, at a randomly chosen time.
 
@@ -9,7 +8,7 @@ jobs:
   update-consul-versions:
     # Only run on main repository
     # Scheduled workflows do not have information about fork status, hence the hardcoded check
-    # if: github.repository == 'G-Research/consuldotnet'
+    if: github.repository == 'G-Research/consuldotnet'
     environment: update-consul-versions
     runs-on: ubuntu-latest
     steps:
@@ -23,9 +22,9 @@ jobs:
 
       - name: Create access token
         id: token
-        # env:
-        #   APP_ID: ${{ secrets.APP_ID }}
-        #   APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
         run: |
           jwt=$(step crypto jwt sign --key /dev/fd/3 --issuer $APP_ID --expiration $(date -d +5min +%s) --subtle 3<<< $APP_PRIVATE_KEY)
           installation_id=$(curl -s -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer $jwt" https://api.github.com/app/installations | jq '.[] | select(.account.login == "${{ github.repository_owner }}") | .id')
@@ -38,7 +37,7 @@ jobs:
         run: Install-Module -Force PowerShellForGitHub
 
       - name: Update consul versions
-        uses: gr-oss-devops/create-pr-action@main
+        uses: technote-space/create-pr-action@v2
         with:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
           EXECUTE_COMMANDS: pwsh .github/workflows/scripts/update-consul-versions.ps1

--- a/.github/workflows/update-consul-versions.yml
+++ b/.github/workflows/update-consul-versions.yml
@@ -1,6 +1,7 @@
 name: "Update Consul versions"
 
 on:
+  push:
   schedule:
     - cron: '22 2 * * *' # Run once per day, at a randomly chosen time.
 
@@ -8,7 +9,7 @@ jobs:
   update-consul-versions:
     # Only run on main repository
     # Scheduled workflows do not have information about fork status, hence the hardcoded check
-    if: github.repository == 'G-Research/consuldotnet'
+    # if: github.repository == 'G-Research/consuldotnet'
     environment: update-consul-versions
     runs-on: ubuntu-latest
     steps:
@@ -22,9 +23,9 @@ jobs:
 
       - name: Create access token
         id: token
-        env:
-          APP_ID: ${{ secrets.APP_ID }}
-          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+        # env:
+        #   APP_ID: ${{ secrets.APP_ID }}
+        #   APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
         run: |
           jwt=$(step crypto jwt sign --key /dev/fd/3 --issuer $APP_ID --expiration $(date -d +5min +%s) --subtle 3<<< $APP_PRIVATE_KEY)
           installation_id=$(curl -s -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer $jwt" https://api.github.com/app/installations | jq '.[] | select(.account.login == "${{ github.repository_owner }}") | .id')
@@ -37,7 +38,7 @@ jobs:
         run: Install-Module -Force PowerShellForGitHub
 
       - name: Update consul versions
-        uses: technote-space/create-pr-action@v2
+        uses: gr-oss-devops/create-pr-action@main
         with:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
           EXECUTE_COMMANDS: pwsh .github/workflows/scripts/update-consul-versions.ps1


### PR DESCRIPTION
#### What type of PR is this?

CI: Resolve deprecation & warning messages in workflows 
Enable DependaBot for GitHub actions

#### What this PR does / why we need it:

Node16 has been out of support since [September 2023](https://github.com/nodejs/Release/#end-of-life-releases). - more info in the [post](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/) 

- Remove `dependabot.yaml` as `dependabot.yml` is only one needed ([commit](https://github.com/gr-oss-devops/geras/pull/1/commits/b0a3bc01a529af7636382ca1f0f436432ccdb519))
- Bump the steps where deprecation/warnings are shown in the job ([commit](https://github.com/gr-oss-devops/consuldotnet/pull/1/commits/3bd9b233fb6f69169b7a26bf2dd69690d302f012))
- Fix `set-output` warnings in workflows ([commit](https://github.com/gr-oss-devops/consuldotnet/pull/1/commits/749824f616c451d2db207ac77da8fd4a39924ad3))


__Optional__

- Resolve on upstream or find alternative for `technote-space/create-pr-action@v2` used in [Update consul versions](https://github.com/G-Research/consuldotnet/actions/runs/8197862332) workflow
- Resolve on upstream `pavlovic-ivan/octo-nudge@v1` used in [Nudge](https://github.com/G-Research/consuldotnet/actions/runs/8466873558) workflow 
    - https://github.com/gr-oss-devops/octo-nudge/pull/1 PR 

#### Which issue(s) this PR fixes:

https://github.com/G-Research/gr-oss/issues/633

------------

# Testing results

**CI**
 - no change

**CodeQL**
 - no change

**Format**
 - no change

**Nudge**
 - 🔴 blocked waiting for https://github.com/G-Research/gr-oss/issues/663

**Deploy website**
 - no change

**Update consul versions** 
 - https://github.com/gr-oss-devops/consuldotnet/actions/runs/8536073624/job/23383845717
