### PR TITLE
CI: Fix warnings & deprecation messages in the workflows

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,8 +1,0 @@
----
-version: 2
-
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -13,6 +13,6 @@ jobs:
     environment: nudge
     steps:
       - name: Send notification
-        uses: pavlovic-ivan/octo-nudge@v1
+        uses: pavlovic-ivan/octo-nudge@v2
         with:
           webhooks: ${{ secrets.NUDGE_WEBHOOKS }}

--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -6,7 +6,6 @@ on:
     types: [completed]
     branches: [master]
 
-
 jobs:
   nudge:
     runs-on: ubuntu-latest

--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -6,6 +6,7 @@ on:
     types: [completed]
     branches: [master]
 
+
 jobs:
   nudge:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-consul-versions.yml
+++ b/.github/workflows/update-consul-versions.yml
@@ -1,14 +1,15 @@
 name: "Update Consul versions"
 
 on:
-  schedule:
-    - cron: '22 2 * * *' # Run once per day, at a randomly chosen time.
+  pull_request:
+  # schedule:
+  #   - cron: '22 2 * * *' # Run once per day, at a randomly chosen time.
 
 jobs:
   update-consul-versions:
     # Only run on main repository
     # Scheduled workflows do not have information about fork status, hence the hardcoded check
-    if: github.repository == 'G-Research/consuldotnet'
+    # if: github.repository == 'G-Research/consuldotnet'
     environment: update-consul-versions
     runs-on: ubuntu-latest
     steps:
@@ -30,7 +31,7 @@ jobs:
           installation_id=$(curl -s -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer $jwt" https://api.github.com/app/installations | jq '.[] | select(.account.login == "${{ github.repository_owner }}") | .id')
           token=$(curl -s -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer $jwt" https://api.github.com/app/installations/$installation_id/access_tokens | jq -r '.token')
           echo "::add-mask::$token"
-          echo "::set-output name=token::$token"
+          echo "token=$token" >> $GITHUB_OUTPUT
 
       - name: Install PowerShellForGitHub
         shell: pwsh

--- a/.github/workflows/update-consul-versions.yml
+++ b/.github/workflows/update-consul-versions.yml
@@ -1,15 +1,14 @@
 name: "Update Consul versions"
 
 on:
-  pull_request:
-  # schedule:
-  #   - cron: '22 2 * * *' # Run once per day, at a randomly chosen time.
+  schedule:
+    - cron: '22 2 * * *' # Run once per day, at a randomly chosen time.
 
 jobs:
   update-consul-versions:
     # Only run on main repository
     # Scheduled workflows do not have information about fork status, hence the hardcoded check
-    # if: github.repository == 'G-Research/consuldotnet'
+    if: github.repository == 'G-Research/consuldotnet'
     environment: update-consul-versions
     runs-on: ubuntu-latest
     steps:

--- a/Consul/Health.cs
+++ b/Consul/Health.cs
@@ -301,6 +301,43 @@ namespace Consul
         }
 
         /// <summary>
+        /// Connect is equivalent to Service, except that it will only return services which are Connect-enabled
+        /// <param name="service">The service ID</param>
+        /// <param name="tag">The service member tag</param>
+        /// <param name="passingOnly">Only return if the health check is in the Passing state</param>
+        /// <param name="q">Customized query options</param>
+        /// <param name="filter">Specifies the expression used to filter the queries results prior to returning the data</param>
+        /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
+        /// <returns>This endpoint returns the connection address for Connect client's to use which may be a proxy in front of the named service</returns>
+        public Task<QueryResult<ServiceEntry[]>> Connect(string service, string tag, bool passingOnly, QueryOptions q, Filter filter, CancellationToken ct = default)
+        {
+            var req = _client.Get<ServiceEntry[]>(string.Format("/v1/health/connect/{0}", service), q, filter);
+            if (!string.IsNullOrEmpty(tag))
+            {
+                req.Params["tag"] = tag;
+            }
+            if (passingOnly)
+            {
+                req.Params["passing"] = "1";
+            }
+            return req.Execute(ct);
+        }
+
+        /// <summary>
+        /// Service is used to query health information along with service info for a given service. It can optionally do server-side filtering on a tag or nodes with passing health checks only.
+        /// <param name="service">The service ID</param>
+        /// <param name="tag">The service member tag</param>
+        /// <param name="passingOnly">Only return if the health check is in the Passing state</param>
+        /// <param name="q">Customized query options</param>
+        /// <param name="filter">Specifies the expression used to filter the queries results prior to returning the data</param>
+        /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
+        /// <returns>This endpoint returns the nodes providing a Connect-capable service in a given datacenter, or a query result with a null response</returns>
+        public Task<QueryResult<ServiceEntry[]>> Connect(string service, string tag, bool passingOnly, QueryOptions q, CancellationToken ct = default)
+        {
+            return Connect(service, tag, passingOnly, q, null, ct);
+        }
+
+        /// <summary>
         /// State is used to retrieve all the checks in a given state. The wildcard "any" state can also be used for all checks.
         /// </summary>
         /// <param name="status">The health status to filter for</param>

--- a/Consul/Interfaces/IHealthEndpoint.cs
+++ b/Consul/Interfaces/IHealthEndpoint.cs
@@ -37,6 +37,8 @@ namespace Consul
         Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, bool passingOnly, CancellationToken ct = default);
         Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, bool passingOnly, QueryOptions q, CancellationToken ct = default);
         Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, bool passingOnly, QueryOptions q, Filter filter, CancellationToken ct = default);
+        Task<QueryResult<ServiceEntry[]>> Connect(string service, string tag, bool passingOnly, QueryOptions q, Filter filter, CancellationToken ct = default);
+        Task<QueryResult<ServiceEntry[]>> Connect(string service, string tag, bool passingOnly, QueryOptions q, CancellationToken ct = default);
         Task<QueryResult<HealthCheck[]>> State(HealthStatus status, CancellationToken ct = default);
         Task<QueryResult<HealthCheck[]>> State(HealthStatus status, QueryOptions q, CancellationToken ct = default);
     }

--- a/docs/docs/2-guides/3-supported-apis.mdx
+++ b/docs/docs/2-guides/3-supported-apis.mdx
@@ -49,12 +49,14 @@ import {ConsulAPIBadge} from "@site/src/components/CustomBadge";
 |                  | Node Service List                 | GET, /v1/catalog/node-services/:node           |   ✅    |
 | Coordinates      | Read WAN Coordinates              | GET /v1/coordinates/datacenters                |   ✅    |
 |                  | Read LAN Coordinates              | GET /v1/coordinates/nodes                      |   ✅    |
+|                  | Read LAN Coordinates for a node   | GET /v1/coordinate/node/:node                  |   ✅    |
 | Events           | Fire Event                        | PUT /v1/event/fire/:name                       |   ✅    |
 |                  | List Events                       | GET /v1/event/list                             |   ✅    |
 | Health           | List Checks for Node              | GET /v1/health/node/:id                        |   ✅    |
 |                  | List Checks for Service           | GET /v1/health/checks/:id                      |   ✅    |
 |                  | List Nodes for Service            | GET /v1/health/service/:id                     |   ✅    |
 |                  | List Checks in State              | GET /v1/health/state/:state                    |   ✅    |
+|                  | List Nodes for connect-capable service | GET /v1/health/connect/:service                |   ✅    |
 | KV Store         | Read Key                          | GET /v1/kv/:key                                |   ✅    |
 |                  | Create/Update Key                 | PUT /v1/kv/:key                                |   ✅    |
 |                  | Delete Key                        | DELETE /v2/kv/:key                             |   ✅    |


### PR DESCRIPTION
#### What type of PR is this?

CI: Resolve deprecation & warning messages in workflows 
Enable DependaBot for GitHub actions

#### What this PR does / why we need it:

Node16 has been out of support since [September 2023](https://github.com/nodejs/Release/#end-of-life-releases). - more info in the [post](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/) 

- Remove `dependabot.yaml` as `dependabot.yml` is only one needed ([commit](https://github.com/gr-oss-devops/geras/pull/1/commits/b0a3bc01a529af7636382ca1f0f436432ccdb519))
- Bump the steps where deprecation/warnings are shown in the job ([commit](https://github.com/gr-oss-devops/consuldotnet/pull/1/commits/3bd9b233fb6f69169b7a26bf2dd69690d302f012))
- Fix `set-output` warnings in workflows ([commit](https://github.com/gr-oss-devops/consuldotnet/pull/1/commits/749824f616c451d2db207ac77da8fd4a39924ad3))


__Optional__

- Resolve on upstream or find alternative for `technote-space/create-pr-action@v2` used in [Update consul versions](https://github.com/G-Research/consuldotnet/actions/runs/8197862332) workflow


#### Which issue(s) this PR fixes:

https://github.com/G-Research/gr-oss/issues/633

------------

# Testing results

**CI**
 - no change

**CodeQL**
 - no change

**Format**
 - no change

**Nudge**
 - https://github.com/gr-oss-devops/consuldotnet/actions/runs/9029288911

**Deploy website**
 - no change

**Update consul versions** 
 - https://github.com/gr-oss-devops/consuldotnet/actions/runs/9000614756
 - __NOTE__: `technote-space/create-pr-action@v2` action is still on Node16, this should be migrated or contributing on the upstream of the action
